### PR TITLE
support for MSWin32

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,7 +9,6 @@ requires 'Carp'           => 0;
 requires 'Encode'         => 0;
 requires 'Exporter::Tidy' => 0;
 requires 'Getopt::Long'   => 2.37;
-requires 'I18N::Langinfo' => 0;
 requires 'List::Util'     => 0;
 requires 'Text::Abbrev'   => 0;
 

--- a/lib/OptArgs.pm
+++ b/lib/OptArgs.pm
@@ -7,7 +7,6 @@ use Exporter::Tidy
   default => [qw/opt arg optargs usage subcmd/],
   other   => [qw/dispatch/];
 use Getopt::Long qw/GetOptionsFromArray/;
-use I18N::Langinfo qw/langinfo/;
 use List::Util qw/max/;
 
 our $VERSION = '0.1.8';
@@ -442,13 +441,13 @@ sub _optargs {
     my $package = $caller;
 
     if ( !@_ and @ARGV ) {
-        my $CODESET = eval { I18N::Langinfo::CODESET() };
+        my $CODESET = eval { require I18N::Langinfo; I18N::Langinfo::CODESET() };
 
         if ($CODESET) {
-            my $codeset = langinfo($CODESET);
+            my $codeset = I18N::Langinfo::langinfo($CODESET);
             $_ = decode( $codeset, $_ ) for @ARGV;
         }
-        else {
+        elsif( $^O ne 'MSWin32') {
             $_ = decode( 'UTF-8', $_ ) for @ARGV;
         }
 


### PR DESCRIPTION
I would like to be able to use this module on Strawberry Perl, but it doesn't have I18N::Langinfo.

This makes it optional.  I don't think it is necessary to make I18N::Langinfo a prereq, since it has been in the core and should be available if the OS supports it since Perl 5.8.

I did some research on the web, and the consensus seems to be that Unicode support in a CMD.EXE / or PowerShell environment is possible, but is unreliable.  The default I believe is ASCII and thus there isn't any reason to default to UTF-8 on MSWin32.
