### PR TITLE
Specify minimum Perl version in Makefile.PL.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,6 +22,8 @@ test_requires 'Test::More';
 test_requires 'Test::Fatal';
 test_requires 'Test::Output';
 
+perl_version '5.006';
+
 author_tests 'xt';
 
 install_script 'bin/optargs';


### PR DESCRIPTION
Hello

I'm participating in the CPAN Pull Request Challenge 2016 and p5-OptArgs is my
January assignment.

Your distribution is generating a warning [1] due to missing declaration of
the minimum Perl version OptArgs can support. As advised, I've run
Perl::MinimumVersion against your modules and the outcome was Perl 5.6.

Cheers

[1]: http://cpants.cpanauthors.org/dist/OptArgs